### PR TITLE
Adjustments to support DGA

### DIFF
--- a/SolidFoundations/Framework/External/SpaceCore/DGAIntegration.cs
+++ b/SolidFoundations/Framework/External/SpaceCore/DGAIntegration.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 #nullable enable
 
-namespace SolidFoundations.Framework.Integrations;
+namespace SolidFoundations.Framework.External.SpaceCore;
 internal static class DGAIntegration
 {
     internal const string DGAModataKey = "spacechase0.DynamicGameAssets/preserved-parent-ID";

--- a/SolidFoundations/Framework/Integrations/DGAIntegration.cs
+++ b/SolidFoundations/Framework/Integrations/DGAIntegration.cs
@@ -35,14 +35,9 @@ internal static class DGAIntegration
         var obj = Expression.Parameter(typeof(object));
         var isinst = Expression.TypeIs(obj, dgaSObject);
 
-        var loc = Expression.Parameter(typeof(string), "fullID");
+        MethodInfo idGetter = dgaSObject.GetProperty("FullId")?.GetGetMethod() ?? throw new InvalidOperationException("DGA SObject's FullId not found....");
 
-        var returnnull = Expression.Assign(loc, Expression.Constant(null));
-
-        MethodInfo idGetter = dgaSObject.GetProperty("FullId").GetGetMethod() ?? throw new InvalidOperationException("DGA SObject's FullId not found....");
-        var getID = Expression.Assign(loc, Expression.Call(obj, idGetter));
-
-        var branch = Expression.IfThenElse(isinst, getID, returnnull);
+        var branch = Expression.IfThenElse(isinst, Expression.Call(obj, idGetter), Expression.Constant(null));
         return Expression.Lambda<Func<object, string?>>(branch, obj).Compile();
     });
 

--- a/SolidFoundations/Framework/Integrations/DGAIntegration.cs
+++ b/SolidFoundations/Framework/Integrations/DGAIntegration.cs
@@ -56,4 +56,15 @@ internal static class DGAIntegration
     /// Null otherwise.
     /// </summary>
     internal static Func<object, string?>? GetDGAFullID => getDGAFullID.Value;
+
+    private static Lazy<Type[]> getSpacecoreTypes = new(() =>
+    {
+        Type? spacecore = AccessTools.TypeByName("SpaceCore.SpaceCore");
+        FieldInfo fieldInfo = AccessTools.Field(spacecore, "ModTypes");
+        if (fieldInfo == null)
+            return Type.EmptyTypes;
+        return (fieldInfo.GetValue(null) as List<Type>)?.ToArray() ?? Type.EmptyTypes;
+    });
+
+    internal static Type[] SpacecoreTypes => getSpacecoreTypes.Value;
 }

--- a/SolidFoundations/Framework/Integrations/DGAIntegration.cs
+++ b/SolidFoundations/Framework/Integrations/DGAIntegration.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using HarmonyLib;
+using System.Linq.Expressions;
+using System.Reflection;
+
+#nullable enable
+
+namespace SolidFoundations.Framework.Integrations;
+internal static class DGAIntegration
+{
+    internal const string DGAModataKey = "spacechase0.DynamicGameAssets/preserved-parent-ID";
+
+    private static Lazy<Func<object, bool>?> isDGASObject = new(() =>
+    {
+        Type? dgaSObject = AccessTools.TypeByName("DynamicGameAssets.Game.CustomObject, DynamicGameAssets");
+        if (dgaSObject is null)
+            return null;
+        var obj = Expression.Parameter(typeof(object));
+        var isinst = Expression.TypeIs(obj, dgaSObject);
+        return Expression.Lambda<Func<object, bool>>(isinst, obj).Compile();
+    });
+
+    /// <summary>
+    /// A function that returns true if an object is a DGA custom object.
+    /// If null, means DGA wasn't loaded (or could not grab the custom type).
+    /// </summary>
+    internal static Func<object, bool>? IsDGASObject => isDGASObject.Value;
+
+    private static Lazy<Func<object, string?>?> getDGAFullID = new(() =>
+    {
+        Type? dgaSObject = AccessTools.TypeByName("DynamicGameAssets.Game.CustomObject, DynamicGameAssets");
+        if (dgaSObject is null)
+            return null;
+
+        var obj = Expression.Parameter(typeof(object));
+        var isinst = Expression.TypeIs(obj, dgaSObject);
+
+        var loc = Expression.Parameter(typeof(string), "fullID");
+
+        var returnnull = Expression.Assign(loc, Expression.Constant(null));
+
+        MethodInfo idGetter = dgaSObject.GetProperty("FullId").GetGetMethod() ?? throw new InvalidOperationException("DGA SObject's FullId not found....");
+        var getID = Expression.Assign(loc, Expression.Call(obj, idGetter));
+
+        var branch = Expression.IfThenElse(isinst, getID, returnnull);
+        return Expression.Lambda<Func<object, string?>>(branch, obj).Compile();
+    });
+
+    /// <summary>
+    /// A function that returns a DGA object's full ID (if applicable).
+    /// Null otherwise.
+    /// </summary>
+    internal static Func<object, string?>? GetDGAFullID => getDGAFullID.Value;
+}

--- a/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
+++ b/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
@@ -270,7 +270,7 @@ namespace SolidFoundations.Framework.Models.ContentPack
                 int num = 0;
                 int num2 = 0;
                 int preserveDroppedInId = -1;
-                string DGAfullID = null;
+                string DGAFullId = null;
                 Chest buildingChest = this.GetBuildingChest(itemConversion.SourceChest);
                 Chest buildingChest2 = this.GetBuildingChest(itemConversion.DestinationChest);
                 if (buildingChest == null)
@@ -297,7 +297,7 @@ namespace SolidFoundations.Framework.Models.ContentPack
                             preserveDroppedInId = item4.ParentSheetIndex;
                             if (DGAIntegration.IsDGASObject?.Invoke(item4) == true)
                             {
-                                DGAfullID = DGAIntegration.GetDGAFullID?.Invoke(item4);
+                                DGAFullId = DGAIntegration.GetDGAFullID?.Invoke(item4);
                             }
                         }
                     }
@@ -369,9 +369,9 @@ namespace SolidFoundations.Framework.Models.ContentPack
                                         if (additionalChopDrops.PreserveID == "DROP_IN" && preserveDroppedInId != -1)
                                         {
                                             obj.preservedParentSheetIndex.Value = preserveDroppedInId;
-                                            if (!string.IsNullOrWhiteSpace(DGAfullID))
+                                            if (!string.IsNullOrWhiteSpace(DGAFullId))
                                             {
-                                                obj.modData[DGAIntegration.DGAModataKey] = DGAfullID;
+                                                obj.modData[DGAIntegration.DGAModataKey] = DGAFullId;
                                             }
                                         }
                                         else if (int.TryParse(additionalChopDrops.PreserveID, out int parentId))

--- a/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
+++ b/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
@@ -351,7 +351,7 @@ namespace SolidFoundations.Framework.Models.ContentPack
                                         if (additionalChopDrops.PreserveID == "DROP_IN" && preserveDroppedInId != -1)
                                         {
                                             obj.preservedParentSheetIndex.Value = preserveDroppedInId;
-                                            if (DGAfullID is not null)
+                                            if (!string.IsNullOrWhiteSpace(DGAfullID))
                                             {
                                                 obj.modData[DGAIntegration.DGAModataKey] = DGAfullID;
                                             }

--- a/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
+++ b/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Netcode;
-using SolidFoundations.Framework.Integrations;
+using SolidFoundations.Framework.External.SpaceCore;
 using SolidFoundations.Framework.Models.Backport;
 using SolidFoundations.Framework.Utilities;
 using SolidFoundations.Framework.Utilities.Backport;

--- a/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
+++ b/SolidFoundations/Framework/Models/Buildings/GenericBuilding.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Netcode;
+using SolidFoundations.Framework.Integrations;
 using SolidFoundations.Framework.Models.Backport;
 using SolidFoundations.Framework.Utilities;
 using SolidFoundations.Framework.Utilities.Backport;
@@ -251,6 +252,7 @@ namespace SolidFoundations.Framework.Models.ContentPack
                 int num = 0;
                 int num2 = 0;
                 int preserveDroppedInId = -1;
+                string DGAfullID = null;
                 Chest buildingChest = this.GetBuildingChest(itemConversion.SourceChest);
                 Chest buildingChest2 = this.GetBuildingChest(itemConversion.DestinationChest);
                 if (buildingChest == null)
@@ -275,6 +277,10 @@ namespace SolidFoundations.Framework.Models.ContentPack
                         {
                             // Item is a fruit, vegetable or roe
                             preserveDroppedInId = item4.ParentSheetIndex;
+                            if (DGAIntegration.IsDGASObject?.Invoke(item4) == true)
+                            {
+                                DGAfullID = DGAIntegration.GetDGAFullID?.Invoke(item4);
+                            }
                         }
                     }
                     if (flag)
@@ -338,13 +344,17 @@ namespace SolidFoundations.Framework.Models.ContentPack
                             {
                                 if (!string.IsNullOrEmpty(additionalChopDrops.PreserveType))
                                 {
-                                    obj.preserve.Value = (PreserveType)Enum.Parse(typeof(PreserveType), additionalChopDrops.PreserveType);
+                                    obj.preserve.Value = Enum.Parse<PreserveType>(additionalChopDrops.PreserveType);
 
                                     if (!string.IsNullOrEmpty(additionalChopDrops.PreserveID))
                                     {
                                         if (additionalChopDrops.PreserveID == "DROP_IN" && preserveDroppedInId != -1)
                                         {
                                             obj.preservedParentSheetIndex.Value = preserveDroppedInId;
+                                            if (DGAfullID is not null)
+                                            {
+                                                obj.modData[DGAIntegration.DGAModataKey] = DGAfullID;
+                                            }
                                         }
                                         else if (int.TryParse(additionalChopDrops.PreserveID, out int parentId))
                                         {

--- a/SolidFoundations/SolidFoundations.cs
+++ b/SolidFoundations/SolidFoundations.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SolidFoundations.Framework.External.ContentPatcher;
+using SolidFoundations.Framework.Integrations;
 using SolidFoundations.Framework.Interfaces.Internal;
 using SolidFoundations.Framework.Managers;
 using SolidFoundations.Framework.Models.Buildings;
@@ -318,7 +319,7 @@ namespace SolidFoundations
                 }
 
                 // Save the custom building objects externally, at the player's save file location
-                XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<GenericBuilding>));
+                XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<GenericBuilding>), DGAIntegration.SpacecoreTypes);
                 using (StreamWriter writer = new StreamWriter(Path.Combine(externalSaveFolderPath, "buildings.json")))
                 {
                     xmlSerializer.Serialize(writer, allExistingCustomBuildings);
@@ -360,7 +361,7 @@ namespace SolidFoundations
 
             // Get the externally saved custom building objects
             var externallySavedCustomBuildings = new List<GenericBuilding>();
-            XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<GenericBuilding>));
+            XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<GenericBuilding>), DGAIntegration.SpacecoreTypes);
             using (StreamReader textReader = new StreamReader(customBuildingsExternalSavePath))
             {
                 externallySavedCustomBuildings = (List<GenericBuilding>)xmlSerializer.Deserialize(textReader);

--- a/SolidFoundations/SolidFoundations.cs
+++ b/SolidFoundations/SolidFoundations.cs
@@ -2,7 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SolidFoundations.Framework.External.ContentPatcher;
-using SolidFoundations.Framework.Integrations;
+using SolidFoundations.Framework.External.SpaceCore;
 using SolidFoundations.Framework.Interfaces.Internal;
 using SolidFoundations.Framework.Managers;
 using SolidFoundations.Framework.Models.Buildings;

--- a/SolidFoundations/SolidFoundations.cs
+++ b/SolidFoundations/SolidFoundations.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SolidFoundations.Framework.External.ContentPatcher;
+using SolidFoundations.Framework.Integrations;
 using SolidFoundations.Framework.Interfaces.Internal;
 using SolidFoundations.Framework.Managers;
 using SolidFoundations.Framework.Models.Buildings;
@@ -328,6 +329,7 @@ namespace SolidFoundations
 
                 // Get all known types for serialization
                 var knownTypes = allExistingCustomBuildings.Where(b => b is not null && b.Model is not null && String.IsNullOrEmpty(b.Model.IndoorMapType) is false && b.Model.IndoorMapTypeAssembly.Equals("Stardew Valley", StringComparison.OrdinalIgnoreCase) is false).Select(b => Type.GetType($"{b.Model.IndoorMapType},{b.Model.IndoorMapTypeAssembly}")).ToArray();
+                knownTypes = knownTypes.Concat(DGAIntegration.SpacecoreTypes).ToArray();
 
                 // Do precheck to see if any buildings can't be serialized and if so, skip them with a warning
                 XmlSerializer filterSerializer = new XmlSerializer(typeof(GenericBuilding), knownTypes);
@@ -417,6 +419,7 @@ namespace SolidFoundations
             {
                 // Get all known types for serialization
                 var knownTypes = buildingManager.GetAllBuildingModels().Where(model => String.IsNullOrEmpty(model.IndoorMapType) is false && model.IndoorMapTypeAssembly.Equals("Stardew Valley", StringComparison.OrdinalIgnoreCase) is false).Select(model => Type.GetType($"{model.IndoorMapType},{model.IndoorMapTypeAssembly}")).ToArray();
+                knownTypes = knownTypes.Concat(DGAIntegration.SpacecoreTypes).ToArray();
 
                 // Get the externally saved custom building objects
                 XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<GenericBuilding>), knownTypes);


### PR DESCRIPTION
two major things:

1. avoid "DGA dummy item wine" by setting the moddata field dga looks at to override the item name.
2. if spacecore is installed, also serialize spacecore types. Given that spacecore is the only mod that currently handles serializer stuff for the vanilla game, I think it's pretty safe.

(neither of these require hard references - it's all done with reflection/expression trees).